### PR TITLE
Make self-closing image tags

### DIFF
--- a/fields/custom/rich-text/index.tsx
+++ b/fields/custom/rich-text/index.tsx
@@ -70,6 +70,7 @@ const write = (value: any, field: Field, config: Record<string, any>) => {
 
     content = content
       .replace(/(<br[^>]*?) *\/?>/g, "$1 />") // self closing br tags
+      .replace(/(<img[^>]*?) *\/?>/g, "$1 />") // self closing img tags
       .replace(/\ style=\"[a-zA-Z0-9\s:\.%_-]*\"/g, "") // remove any table style attrs
       .replaceAll("rowspan=", "rowSpan=") // lightly make html Tables react dom ready...
       .replaceAll("colspan=", "colSpan=")


### PR DESCRIPTION
This line was apparently an early fix I made to the CMS (March 4 2025 commit), but which was not preserved in recent upgrade. Img tags without self-closure are valid html but cause issues with the markdown processor. This change ensure that img tags have the closing slash in them.